### PR TITLE
Add support for shopping vertical

### DIFF
--- a/instructions.html
+++ b/instructions.html
@@ -14,6 +14,7 @@
     <ol>
         <li>If you are using Windows then Double Shot should already be your default search engine.</li>
         <!-- <li><b>Or</b> if that's not the case you can <a href='https://www.doubleshotsearch.download/chrome-extension/add-search-engine.php' target='_blank'><b>set it as a default search engine</b></a> so you can search directly from the address bar. -->
+        <li><b>Or</b> you can also use it to shop for products: go to the address bar and write <b><i>shop &lt;space&gt; query</i></b>, then press enter.</b>
         <li><b>Or</b> you can also use it using an address bar shortcut: go to the address bar and write <b><i>ds &lt;space&gt; query</i></b>, then press enter.</b>
         <li><b>Or</b> you can search below by typing a query and pressing Enter.
     </ol>

--- a/search.js
+++ b/search.js
@@ -1,11 +1,19 @@
+const shopPrefix = "shop ";
 $( document ).ready(function() {
+    let left = "https://www.bing.com/search?q=";
+    let right = "https://www.google.com/search?q=";
     var url = $.url();
     var query = url.param("q");
-        
+
     if (typeof query != 'undefined')
     {
-        $("#left").attr("src", "https://www.bing.com/search?q=" + encodeURIComponent(query));
-        $("#right").attr("src", "https://www.google.com/search?q=" + encodeURIComponent(query));
+        if (query.indexOf(shopPrefix) === 0) {
+            query = query.substr(shopPrefix.length);
+            left = left.replace("search?", "shop?");
+            right = right.replace("search?", "search?psb=1&tbm=shop&");
+        }
+        $("#left").attr("src", left + encodeURIComponent(query));
+        $("#right").attr("src", right + encodeURIComponent(query));
         document.title = query.replace(/</g, "&lt;").replace(/>/g, "&gt;") + " - Double Shot Search";
     }
 });


### PR DESCRIPTION
Non-breaking changes. Prefix "shop" helps the extension invoke shopping vertical. By default, it will be a comparison between Bing Search & Google search.