### PR TITLE
Support the Edge version 111.0.1661.54

### DIFF
--- a/background.js
+++ b/background.js
@@ -90,7 +90,10 @@ chrome.webRequest.onBeforeRequest.addListener(
                     });
                 });
             } else {
-              return { redirectUrl: search_url };
+                // Update to support the Edge version: 111.0.1661.54
+                chrome.tabs.query({ active: true, currentWindow: true }, function (tabs) {
+                    chrome.tabs.update(tabs[0].id, { url: search_url });
+                });
             }
         }
     },

--- a/manifest-edge.json
+++ b/manifest-edge.json
@@ -1,6 +1,10 @@
 {
    "background": {
-      "scripts": [ "jquery-1.11.1.min.js", "purl.js", "background.js" ]
+      "scripts": [
+         "jquery-1.11.1.min.js",
+         "purl.js",
+         "background.js"
+      ]
    },
    "browser_action": {
       "default_icon": "DoubleShotSearchLogo32.png",
@@ -31,13 +35,28 @@
    "omnibox": {
       "keyword": "ds"
    },
-   "content_scripts": [{
-      "matches": ["https://www.google.co.in/*", "https://www.google.com/*", "https://www.bing.com/*"],
-      "all_frames": true,
-      "js": ["content.js"]
-    }],
-   "permissions": [ "webRequest", "webRequestBlocking", "\u003Call_urls>", "activeTab" ],
+   "content_scripts": [
+      {
+         "matches": [
+            "https://www.google.co.in/*",
+            "https://www.google.com/*",
+            "https://www.bing.com/*"
+         ],
+         "all_frames": true,
+         "js": [
+            "content.js"
+         ]
+      }
+   ],
+   "permissions": [
+      "webRequest",
+      "webRequestBlocking",
+      "<all_urls>",
+      "activeTab"
+   ],
    "short_name": "Double Shot Search",
-   "version": "2.6",
-   "web_accessible_resources": [ "search.html" ]
+   "version": "3.0",
+   "web_accessible_resources": [
+      "search.html"
+   ]
 }

--- a/manifest.json
+++ b/manifest.json
@@ -1,6 +1,10 @@
 {
    "background": {
-      "scripts": [ "jquery-1.11.1.min.js", "purl.js", "background.js" ]
+      "scripts": [
+         "jquery-1.11.1.min.js",
+         "purl.js",
+         "background.js"
+      ]
    },
    "browser_action": {
       "default_icon": "DoubleShotSearchLogo32.png",
@@ -31,18 +35,38 @@
    "omnibox": {
       "keyword": "ds"
    },
-   "content_scripts": [{
-      "matches": ["https://www.google.co.in/*", "https://www.google.com/*", "https://www.bing.com/*"],
-      "all_frames": true,
-      "js": ["content.js"]
-    },
-    {
-      "matches": ["https://bard.google.com/*"],
-      "js": ["bard.js"]
-    }],
-   "permissions": [ "webRequest", "webRequestBlocking", "\u003Call_urls>", "activeTab", "tabs" ],
+   "content_scripts": [
+      {
+         "matches": [
+            "https://www.google.co.in/*",
+            "https://www.google.com/*",
+            "https://www.bing.com/*"
+         ],
+         "all_frames": true,
+         "js": [
+            "content.js"
+         ]
+      },
+      {
+         "matches": [
+            "https://bard.google.com/*"
+         ],
+         "js": [
+            "bard.js"
+         ]
+      }
+   ],
+   "permissions": [
+      "webRequest",
+      "webRequestBlocking",
+      "<all_urls>",
+      "activeTab",
+      "tabs"
+   ],
    "short_name": "Double Shot Search",
    "update_url": "https://clients2.google.com/service/update2/crx",
-   "version": "2.6",
-   "web_accessible_resources": [ "search.html" ]
+   "version": "3.0",
+   "web_accessible_resources": [
+      "search.html"
+   ]
 }


### PR DESCRIPTION
The redirectUrl parameter has a problem with the new version of Edge (111.0.1661.54)

This fix is a work around to make the redirection happen.

Also, since we are supporting Chat, we update the version to 3.0