### PR TITLE
Support case insensitive for the "chat" and "shop" prefix

### DIFF
--- a/background.js
+++ b/background.js
@@ -69,6 +69,9 @@ function navigate(url) {
     });
 }
 
+const shopPrefix = "shop";
+const chatPrefix = "chat";
+
 chrome.webRequest.onBeforeRequest.addListener(
     function (details) {
         if (details.url.indexOf("https://www.doubleshotsearch.download/chrome-extension/search/?q=") !== -1
@@ -77,6 +80,22 @@ chrome.webRequest.onBeforeRequest.addListener(
             var query = url.param("q");
             var search_url = chrome.runtime.getURL("search.html");
             search_url = search_url + "?q=" + encodeURIComponent(query);
+
+            let queryWords = query.split(" ");
+            if (queryWords.length > 1) {
+                switch (queryWords[0].toLowerCase()) {
+                    case shopPrefix:
+                        queryWords[0] = shopPrefix;
+                        query = queryWords.join(" ");
+                        break;
+                    case chatPrefix:
+                        queryWords[0] = chatPrefix;
+                        query = queryWords.join(" ");
+                        break;
+                    default:
+                        break;
+                }
+            }
 
             if (query.startsWith("chat ")) {
                 chrome.tabs.query({ active: true, currentWindow: true }, function (tabs) {

--- a/manifest-edge.json
+++ b/manifest-edge.json
@@ -64,7 +64,7 @@
       "tabs"
    ],
    "short_name": "Double Shot Search",
-   "version": "3.0.1",
+   "version": "3.0.2",
    "web_accessible_resources": [
       "search.html"
    ]

--- a/manifest.json
+++ b/manifest.json
@@ -65,7 +65,7 @@
    ],
    "short_name": "Double Shot Search",
    "update_url": "https://clients2.google.com/service/update2/crx",
-   "version": "3.0.1",
+   "version": "3.0.2",
    "web_accessible_resources": [
       "search.html"
    ]


### PR DESCRIPTION
Now, user can search by "Shop earrings" or "shop earrings" or "SHOP earrings".

This change also applies to "chat" as well.